### PR TITLE
feat: add wait-for-batch-run command

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -349,7 +349,6 @@ func ExecuteBatchRun(urlBase string, apiToken string, organization string, proje
 		return nil, false, false, exitErr
 	}
 
-	crossBatchRunTotalTestCount := batchRun.Test_Cases.Total
 	printMessage(printResult, "test result page:\n")
 	printMessage(printResult, "%s\n", batchRun.Url)
 
@@ -358,6 +357,14 @@ func ExecuteBatchRun(urlBase string, apiToken string, organization string, proje
 		return batchRun, false, false, nil
 	}
 
+	return WaitForBatchRunResult(urlBase, apiToken, organization, project, httpHeadersMap, batchRun, waitLimit, printResult)
+}
+
+func WaitForBatchRunResult(urlBase string, apiToken string, organization string, project string,
+	httpHeadersMap map[string]string, batchRun *BatchRun,
+	waitLimit int, printResult bool) (*BatchRun /*on which magicpod bitrise step depends */, bool, bool, *cli.ExitError) {
+
+	crossBatchRunTotalTestCount := batchRun.Test_Cases.Total
 	const initRetryInterval = 10 // retry more frequently at first
 	const retryInterval = 60
 	var limitSeconds int


### PR DESCRIPTION
in order to improve ci experience.

# Checks
## batch-run command
### given a wait option (--wait_limit)
#### when a timeout happens
- [x] it should end up with `...batch run never finished` message
- [x] the exit status should be 1
#### when a timeout does not happen
- [x] it should end up with `..batch run succeeded` message
- [x] the exit status should be 0
### given a no wait option (--no_wait)
- [x] it should end up with `test result page:
https://app.magicpod.com/<organization name>/<project name>/batch-run/<batch run number>/` message
- [x] the exit status should be 0
## wait-for-batch-run command
### when a timeout happens
- [x] it should end up with `...batch run never finished` message
- [x] the exit status should be 1
### when a timeout does not happen
- [x] it should end up with `..batch run succeeded` message
- [x] the exit status should be 0