### PR TITLE
docs: comment of -H option, to add an example of accept-language

### DIFF
--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -317,7 +317,7 @@ func commonFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  "http_headers, H",
-			Usage: "Additional HTTP headers in JSON string format(e.g.: '{"accept-language":"ja"}')",
+			Usage: "Additional HTTP headers in JSON string format (e.g.: '{\"accept-language\":\"ja\"}')",
 		},
 	}
 }

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -317,7 +317,7 @@ func commonFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  "http_headers, H",
-			Usage: "Additional HTTP headers in JSON string format",
+			Usage: "Additional HTTP headers in JSON string format(e.g.: '{"accept-language":"ja"}')",
 		},
 	}
 }


### PR DESCRIPTION
### Motivation
I struggled to find out what determines the language in which test results logs and emails are displayed.

### What I changed
I added an example when specifying `accept-language` with the `-H` option,  as bellows;

- [Knowing What Determines the Language in Which Test Result Logs and Emails Are Displayed – MagicPod Help Center](https://support.magic-pod.com/hc/en-us/articles/4409355310233-Knowing-What-Determines-the-Language-in-Which-Test-Result-Logs-and-Emails-Are-Displayed)

### What I checked
Checked manually if `go build` command works