### PR TITLE
docs: Modify README.md about wait_limit option of batch-run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ wait $PID1
 wait $PID2
 ```
 
+> **Note**: The default of Wait limit in seconds is 300 seconds.
+
+You can also specify the wait limit in seconds. If execution time of your [BatchRun/CrossBatchRun](https://app.magicpod.com/api/v1.0/doc/) is expected to exceed the value of test count x 10 minutes, it would be better to specify as follows.
+
+```
+./magicpod-api-client batch-run -p <project_1> -S <test_settings_number_1> -w <seconds to wait> &
+PID1=$!
+```
+
+See the details.
+
+```
+./magicpod-api-client batch-run --help
+```
+
 ## Build from source
 
 Run the following in the top directory of this repository.


### PR DESCRIPTION
### Motivation
I'd like to share with you that you can also make a use of `wait_limit` option, when using the `wait` command to wait for the `./magicpod-api-client batch-run` command to finish.

### What I changed
I added an example of the `wait_limit` option.

Ref. https://github.com/Magic-Pod/magicpod-api-client/blob/beb27eebd35222cfd55c779fba324bf505dc11d1/magicpod-api-client.go#L43-L45

### What I checked
Checked manually if comparing the output of `./magicpod-api-client batch-run --help` command.