### PR TITLE
feat: get batch run result

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -31,7 +31,7 @@ type BatchRun struct {
 		Unresolved int `json:"unresolved"`
 		Total      int `json:"total"`
 		Details    []struct {
-			PatternName    string     `json:"pattern_name"`
+			PatternName    *string    `json:"pattern_name"`
 			IncludedLabels []string   `json:"included_labels"`
 			ExcludedLabels []string   `json:"excluded_labels"`
 			Results        []TestCase `json:"results"`
@@ -42,7 +42,7 @@ type BatchRun struct {
 
 type TestCase struct {
 	Order        int           `json:"order"`
-	Number       int           `json:"number"`
+	Number       *int          `json:"number"`
 	Status       string        `json:"status"`
 	StartedAt    string        `json:"started_at"`
 	FinishedAt   string        `json:"finished_at"`

--- a/common/common.go
+++ b/common/common.go
@@ -25,10 +25,10 @@ type BatchRun struct {
 	StartedAt        string `json:"started_at"`
 	FinishedAt       string `json:"finished_at"`
 	TestCases        struct {
-		Succeeded  int `json:"succeeded"`
-		Failed     int `json:"failed"`
-		Aborted    int `json:"aborted"`
-		Unresolved int `json:"unresolved"`
+		Succeeded  int `json:"succeeded,omitempty"`
+		Failed     int `json:"failed,omitempty"`
+		Aborted    int `json:"aborted,omitempty"`
+		Unresolved int `json:"unresolved,omitempty"`
 		Total      int `json:"total"`
 		Details    []struct {
 			PatternName    *string    `json:"pattern_name"`

--- a/common/common.go
+++ b/common/common.go
@@ -16,16 +16,44 @@ import (
 
 // BatchRun stands for a batch run executed on the server
 type BatchRun struct {
-	Url            string
-	Status         string
-	BatchRunNumber int
-	TestCases      struct {
-		Succeeded  int
-		Failed     int
-		Aborted    int
-		Unresolved int
-		Total      int
-	}
+	OrganizationName string `json:"organization_name"`
+	ProjectName      string `json:"project_name"`
+	BatchRunNumber   int    `json:"batch_run_number"`
+	TestSettingName  string `json:"test_setting_name"`
+	Status           string `json:"status"`
+	StatusNumber     int    `json:"status_number"`
+	StartedAt        string `json:"started_at"`
+	FinishedAt       string `json:"finished_at"`
+	TestCases        struct {
+		Succeeded  int `json:"succeeded"`
+		Failed     int `json:"failed"`
+		Aborted    int `json:"aborted"`
+		Unresolved int `json:"unresolved"`
+		Total      int `json:"total"`
+		Details    []struct {
+			PatternName    string     `json:"pattern_name"`
+			IncludedLabels []string   `json:"included_labels"`
+			ExcludedLabels []string   `json:"excluded_labels"`
+			Results        []TestCase `json:"results"`
+		} `json:"details"`
+	} `json:"test_cases"`
+	Url string `json:"url"`
+}
+
+type TestCase struct {
+	Order        int           `json:"order"`
+	Number       int           `json:"number"`
+	Status       string        `json:"status"`
+	StartedAt    string        `json:"started_at"`
+	FinishedAt   string        `json:"finished_at"`
+	DataPatterns []DataPattern `json:"data_patterns"`
+}
+
+type DataPattern struct {
+	DataIndex  int    `json:"data_index"`
+	Status     string `json:"status"`
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at"`
 }
 
 // BatchRuns stands for a group of batch runs executed on the server

--- a/common/common.go
+++ b/common/common.go
@@ -25,6 +25,8 @@ type BatchRun struct {
 	StartedAt        string `json:"started_at"`
 	FinishedAt       string `json:"finished_at"`
 	TestCases        struct {
+		NotRunning int `json:"not-running,omitempty"`
+		Running    int `json:"running,omitempty"`
 		Succeeded  int `json:"succeeded,omitempty"`
 		Failed     int `json:"failed,omitempty"`
 		Aborted    int `json:"aborted,omitempty"`

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -48,6 +48,17 @@ func main() {
 			Action: batchRunAction,
 		},
 		{
+			Name:  "get-batch-run",
+			Usage: "Get batch run result",
+			Flags: append(commonFlags(), []cli.Flag{
+				cli.IntFlag{
+					Name:  "batch_run_number, b",
+					Usage: "Batch run number",
+				},
+			}...),
+			Action: getBatchRunAction,
+		},
+		{
 			Name:   "latest-batch-run-no",
 			Usage:  "Get the latest batch run number",
 			Flags:  commonFlags(),
@@ -131,6 +142,28 @@ func main() {
 		},
 	}
 	app.Run(os.Args)
+}
+
+func getBatchRunAction(c *cli.Context) error {
+	urlBase, apiToken, organization, project, httpHeadersMap, err := parseCommonFlags(c)
+	if err != nil {
+		return err
+	}
+
+	batchRunNumber := c.Int("batch_run_number")
+	if batchRunNumber == 0 {
+		return cli.NewExitError("--batch_run_number option is not specified or 0", 1)
+	}
+	batchRun, exitErr := common.GetBatchRun(urlBase, apiToken, organization, project, httpHeadersMap, batchRunNumber)
+	if exitErr != nil {
+		return exitErr
+	}
+	b, err := json.Marshal(batchRun)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
 }
 
 func latestBatchRunNoAction(c *cli.Context) error {


### PR DESCRIPTION
### What I change

Add command to get batch run result

For the endpoint `/v1.0/{organization_name}/{project_name}/batch-run/{batch_run_number}/`.

Feature for #7 (partially resolves it)

### What I checked

Manually checked if the response body obtained by GET request using `curl` and the one by this command are identical.

~The slight difference
Precisely speaking, not exactly identical. In the API doc, running and not-running count are not documented but included in the response body.~