### PR TITLE
feat: adapt get-batch-run to MagicPod v0.99.36

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -33,16 +33,16 @@ type BatchRun struct {
 		Unresolved int `json:"unresolved,omitempty"`
 		Total      int `json:"total"`
 		Details    []struct {
-			PatternName    *string    `json:"pattern_name"`
-			IncludedLabels []string   `json:"included_labels"`
-			ExcludedLabels []string   `json:"excluded_labels"`
-			Results        []TestCase `json:"results"`
+			PatternName    *string          `json:"pattern_name"`
+			IncludedLabels []string         `json:"included_labels"`
+			ExcludedLabels []string         `json:"excluded_labels"`
+			Results        []TestCaseResult `json:"results"`
 		} `json:"details"`
 	} `json:"test_cases"`
 	Url string `json:"url"`
 }
 
-type TestCase struct {
+type TestCaseResult struct {
 	Order        int           `json:"order"`
 	Status       string        `json:"status"`
 	StartedAt    string        `json:"started_at"`

--- a/common/common.go
+++ b/common/common.go
@@ -44,7 +44,6 @@ type BatchRun struct {
 
 type TestCase struct {
 	Order        int           `json:"order"`
-	Number       *int          `json:"number"`
 	Status       string        `json:"status"`
 	StartedAt    string        `json:"started_at"`
 	FinishedAt   string        `json:"finished_at"`

--- a/common/common.go
+++ b/common/common.go
@@ -43,7 +43,12 @@ type BatchRun struct {
 }
 
 type TestCaseResult struct {
-	Order        int           `json:"order"`
+	Order    int `json:"order"`
+	TestCase struct {
+		Number int    `json:"number"`
+		Name   string `json:"name"`
+		Url    string `json:"url"`
+	} `json:"test_case"`
 	Status       string        `json:"status"`
 	StartedAt    string        `json:"started_at"`
 	FinishedAt   string        `json:"finished_at"`


### PR DESCRIPTION
### What I change

Replace `number` field with the URL included object.

### What I checked

Manually checked if the response body obtained by GET request using `curl` and the one by this command are identical.

The difference is the `number` field. It is still included in the response.