### PR TITLE
feat: get batch runs

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -64,7 +64,28 @@ type DataPattern struct {
 
 // BatchRuns stands for a group of batch runs executed on the server
 type BatchRuns struct {
-	BatchRuns []BatchRun
+	OrganizationName string            `json:"organization_name"`
+	ProjectName      string            `json:"project_name"`
+	BatchRuns        []BatchRunSummary `json:"batch_runs"`
+}
+
+type BatchRunSummary struct {
+	BatchRunNumber  int    `json:"batch_run_number"`
+	TestSettingName string `json:"test_setting_name"`
+	Status          string `json:"status"`
+	StatusNumber    int    `json:"status_number"`
+	StartedAt       string `json:"started_at"`
+	FinishedAt      string `json:"finished_at"`
+	TestCases       struct {
+		NotRunning int `json:"not-running,omitempty"`
+		Running    int `json:"running,omitempty"`
+		Succeeded  int `json:"succeeded,omitempty"`
+		Failed     int `json:"failed,omitempty"`
+		Aborted    int `json:"aborted,omitempty"`
+		Unresolved int `json:"unresolved,omitempty"`
+		Total      int `json:"total"`
+	} `json:"test_cases"`
+	Url string `json:"url"`
 }
 
 // UploadFile stands for a file to be uploaded to the server

--- a/common/common.go
+++ b/common/common.go
@@ -228,7 +228,7 @@ func GetBatchRun(urlBase string, apiToken string, organization string, project s
 	return res.Result().(*BatchRun), nil
 }
 
-func GetBatchRuns(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string, count int, maxBatchRunNumber int, minBatchRunNumber int) (*BatchRuns, *cli.ExitError) {
+func getBatchRuns(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string, count int, maxBatchRunNumber int, minBatchRunNumber int) (*resty.Response, error) {
 	req := createBaseRequest(urlBase, apiToken, organization, project, httpHeadersMap).
 		SetQueryParam("count", strconv.Itoa(count)).
 		SetResult(BatchRuns{})
@@ -239,8 +239,11 @@ func GetBatchRuns(urlBase string, apiToken string, organization string, project 
 	if minBatchRunNumber > 0 {
 		req.SetQueryParam("min_batch_run_number", strconv.Itoa(minBatchRunNumber))
 	}
+	return req.Get("/{organization}/{project}/batch-runs/")
+}
 
-	res, err := req.Get("/{organization}/{project}/batch-runs/")
+func GetBatchRuns(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string, count int, maxBatchRunNumber int, minBatchRunNumber int) (*BatchRuns, *cli.ExitError) {
+	res, err := getBatchRuns(urlBase, apiToken, organization, project, httpHeadersMap, count, maxBatchRunNumber, minBatchRunNumber)
 	if err != nil {
 		panic(err)
 	}
@@ -251,10 +254,7 @@ func GetBatchRuns(urlBase string, apiToken string, organization string, project 
 }
 
 func LatestBatchRunNo(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string) (int, *cli.ExitError) {
-	res, err := createBaseRequest(urlBase, apiToken, organization, project, httpHeadersMap).
-		SetQueryParam("count", "1").
-		SetResult(BatchRuns{}).
-		Get("/{organization}/{project}/batch-runs/")
+	res, err := getBatchRuns(urlBase, apiToken, organization, project, httpHeadersMap, 1, 0, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -14,6 +14,16 @@ import (
 	"github.com/urfave/cli"
 )
 
+type testCasesCounter struct {
+	NotRunning int `json:"not-running,omitempty"`
+	Running    int `json:"running,omitempty"`
+	Succeeded  int `json:"succeeded,omitempty"`
+	Failed     int `json:"failed,omitempty"`
+	Aborted    int `json:"aborted,omitempty"`
+	Unresolved int `json:"unresolved,omitempty"`
+	Total      int `json:"total"`
+}
+
 // BatchRun stands for a batch run executed on the server
 type BatchRun struct {
 	OrganizationName string `json:"organization_name"`
@@ -25,14 +35,8 @@ type BatchRun struct {
 	StartedAt        string `json:"started_at"`
 	FinishedAt       string `json:"finished_at"`
 	TestCases        struct {
-		NotRunning int `json:"not-running,omitempty"`
-		Running    int `json:"running,omitempty"`
-		Succeeded  int `json:"succeeded,omitempty"`
-		Failed     int `json:"failed,omitempty"`
-		Aborted    int `json:"aborted,omitempty"`
-		Unresolved int `json:"unresolved,omitempty"`
-		Total      int `json:"total"`
-		Details    []struct {
+		testCasesCounter
+		Details []struct {
 			PatternName    *string          `json:"pattern_name"`
 			IncludedLabels []string         `json:"included_labels"`
 			ExcludedLabels []string         `json:"excluded_labels"`
@@ -77,13 +81,7 @@ type BatchRunSummary struct {
 	StartedAt       string `json:"started_at"`
 	FinishedAt      string `json:"finished_at"`
 	TestCases       struct {
-		NotRunning int `json:"not-running,omitempty"`
-		Running    int `json:"running,omitempty"`
-		Succeeded  int `json:"succeeded,omitempty"`
-		Failed     int `json:"failed,omitempty"`
-		Aborted    int `json:"aborted,omitempty"`
-		Unresolved int `json:"unresolved,omitempty"`
-		Total      int `json:"total"`
+		testCasesCounter
 	} `json:"test_cases"`
 	Url string `json:"url"`
 }

--- a/common/common.go
+++ b/common/common.go
@@ -228,6 +228,28 @@ func GetBatchRun(urlBase string, apiToken string, organization string, project s
 	return res.Result().(*BatchRun), nil
 }
 
+func GetBatchRuns(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string, count int, maxBatchRunNumber int, minBatchRunNumber int) (*BatchRuns, *cli.ExitError) {
+	req := createBaseRequest(urlBase, apiToken, organization, project, httpHeadersMap).
+		SetQueryParam("count", strconv.Itoa(count)).
+		SetResult(BatchRuns{})
+	// Optional filtering parameters.
+	if maxBatchRunNumber > 0 {
+		req.SetQueryParam("max_batch_run_number", strconv.Itoa(maxBatchRunNumber))
+	}
+	if minBatchRunNumber > 0 {
+		req.SetQueryParam("min_batch_run_number", strconv.Itoa(minBatchRunNumber))
+	}
+
+	res, err := req.Get("/{organization}/{project}/batch-runs/")
+	if err != nil {
+		panic(err)
+	}
+	if exitErr := handleError(res); exitErr != nil {
+		return nil, exitErr
+	}
+	return res.Result().(*BatchRuns), nil
+}
+
 func LatestBatchRunNo(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string) (int, *cli.ExitError) {
 	res, err := createBaseRequest(urlBase, apiToken, organization, project, httpHeadersMap).
 		SetQueryParam("count", "1").

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -197,7 +197,7 @@ func getBatchRunsAction(c *cli.Context) error {
 	count := c.Int("count")
 	maxBatchRunNumber := c.Int("max_batch_run_number")
 	minBatchRunNumber := c.Int("min_batch_run_number")
-	if maxBatchRunNumber < minBatchRunNumber {
+	if maxBatchRunNumber != 0 && minBatchRunNumber != 0 && maxBatchRunNumber < minBatchRunNumber {
 		return cli.NewExitError("--max_batch_run_number value is smaller than --min_batch_run_number value", 1)
 	}
 	batchRuns, exitErr := common.GetBatchRuns(urlBase, apiToken, organization, project, httpHeadersMap, count, maxBatchRunNumber, minBatchRunNumber)

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -197,6 +197,9 @@ func getBatchRunsAction(c *cli.Context) error {
 	count := c.Int("count")
 	maxBatchRunNumber := c.Int("max_batch_run_number")
 	minBatchRunNumber := c.Int("min_batch_run_number")
+	if maxBatchRunNumber < minBatchRunNumber {
+		return cli.NewExitError("--max_batch_run_number value is smaller than --min_batch_run_number value", 1)
+	}
 	batchRuns, exitErr := common.GetBatchRuns(urlBase, apiToken, organization, project, httpHeadersMap, count, maxBatchRunNumber, minBatchRunNumber)
 	if exitErr != nil {
 		return exitErr

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -59,6 +59,28 @@ func main() {
 			Action: getBatchRunAction,
 		},
 		{
+			Name:  "get-batch-runs",
+			Usage: "Get the batch runs information in the **most recent first** order.",
+			Flags: append(commonFlags(), []cli.Flag{
+				cli.IntFlag{
+					Name:  "count, c",
+					Usage: "The maximum number of records to retrieve.",
+					Value: 20,
+				},
+				cli.IntFlag{
+					Name:     "max_batch_run_number, max",
+					Usage:    "The most recent batch run number to start retrieving records from.",
+					Required: false,
+				},
+				cli.IntFlag{
+					Name:     "min_batch_run_number, min",
+					Usage:    "The least recent batch run number to stop retrieving records at.",
+					Required: false,
+				},
+			}...),
+			Action: getBatchRunsAction,
+		},
+		{
 			Name:   "latest-batch-run-no",
 			Usage:  "Get the latest batch run number",
 			Flags:  commonFlags(),
@@ -163,6 +185,10 @@ func getBatchRunAction(c *cli.Context) error {
 		return err
 	}
 	fmt.Println(string(b))
+	return nil
+}
+
+func getBatchRunsAction(c *cli.Context) error {
 	return nil
 }
 

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -189,6 +189,23 @@ func getBatchRunAction(c *cli.Context) error {
 }
 
 func getBatchRunsAction(c *cli.Context) error {
+	urlBase, apiToken, organization, project, httpHeadersMap, err := parseCommonFlags(c)
+	if err != nil {
+		return err
+	}
+
+	count := c.Int("count")
+	maxBatchRunNumber := c.Int("max_batch_run_number")
+	minBatchRunNumber := c.Int("min_batch_run_number")
+	batchRuns, exitErr := common.GetBatchRuns(urlBase, apiToken, organization, project, httpHeadersMap, count, maxBatchRunNumber, minBatchRunNumber)
+	if exitErr != nil {
+		return exitErr
+	}
+	b, err := json.Marshal(batchRuns)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
 	return nil
 }
 


### PR DESCRIPTION
## What I change

Add a feature to get `/batch-runs/` response.

Resolves #7

## What I checked

Manually compared the response with the one using cURL including `count`, `max_batch_run_number` and `min_batch_run_number`.

I found some property order in `testCasesCounter` was a bit different (example below) but I think the order in the API doc is reasonable and server side implementation should be fixed.

The deletion lines are from cURL and addition lines are from this tool.

```diff
 "test_cases": {
   "succeeded": 1,
-  "total": 2,
-  "unresolved": 1
+  "unresolved": 1,
+  "total": 2
 },
```
