### PR TITLE
feat: task duration in seconds for batch run info

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -24,6 +24,11 @@ type testCasesCounter struct {
 	Total      int `json:"total"`
 }
 
+type taskInterval struct {
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at"`
+}
+
 // BatchRun stands for a batch run executed on the server
 type BatchRun struct {
 	OrganizationName string `json:"organization_name"`
@@ -32,9 +37,8 @@ type BatchRun struct {
 	TestSettingName  string `json:"test_setting_name"`
 	Status           string `json:"status"`
 	StatusNumber     int    `json:"status_number"`
-	StartedAt        string `json:"started_at"`
-	FinishedAt       string `json:"finished_at"`
-	TestCases        struct {
+	taskInterval
+	TestCases struct {
 		testCasesCounter
 		Details []struct {
 			PatternName    *string          `json:"pattern_name"`
@@ -53,9 +57,8 @@ type TestCaseResult struct {
 		Name   string `json:"name"`
 		Url    string `json:"url"`
 	} `json:"test_case"`
-	Status       string        `json:"status"`
-	StartedAt    string        `json:"started_at"`
-	FinishedAt   string        `json:"finished_at"`
+	Status string `json:"status"`
+	taskInterval
 	DataPatterns []DataPattern `json:"data_patterns"`
 }
 
@@ -78,9 +81,8 @@ type BatchRunSummary struct {
 	TestSettingName string `json:"test_setting_name"`
 	Status          string `json:"status"`
 	StatusNumber    int    `json:"status_number"`
-	StartedAt       string `json:"started_at"`
-	FinishedAt      string `json:"finished_at"`
-	TestCases       struct {
+	taskInterval
+	TestCases struct {
 		testCasesCounter
 	} `json:"test_cases"`
 	Url string `json:"url"`

--- a/common/common.go
+++ b/common/common.go
@@ -25,8 +25,9 @@ type testCasesCounter struct {
 }
 
 type taskInterval struct {
-	StartedAt  string `json:"started_at"`
-	FinishedAt string `json:"finished_at"`
+	StartedAt       string   `json:"started_at"`
+	FinishedAt      string   `json:"finished_at"`
+	DurationSeconds *float64 `json:"duration_seconds"`
 }
 
 // BatchRun stands for a batch run executed on the server


### PR DESCRIPTION
### What I change

> **Note**
> The field was added in MagicPod v0.99.39.

Add task duration in seconds to `get-batch-run` and `get-batch-runs` commands. The duration is available for the results of test case and batch run.

### What I checked

Compared diff of the responses with the ones from `cURL` for the following endpoints. Some diffs were detected but all of them seem negligible.

- `/batch-run/{batch_run_number}/`: The obsolete `number` field. (cf. #9)
- `/batch-runs/`: The order of test cases count mentioned in #10.