### PR TITLE
fix: add json unmarshalling for FileNo

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -91,7 +91,7 @@ type BatchRunSummary struct {
 
 // UploadFile stands for a file to be uploaded to the server
 type UploadFile struct {
-	FileNo int
+	FileNo int `json:"file_no"`
 }
 
 func zipAppDir(dirPath string) string {


### PR DESCRIPTION
## Intent

Parse the file number in the `.../upload-file/` response.

## Confirmed

For `upload-app` command, manually checked that a positive value corresponds to the file number is returned.