### PR TITLE
fix: add option "-B" for branch for batch-run

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -431,7 +431,7 @@ func printMessage(printResult bool, format string, args ...interface{}) {
 
 // ExecuteBatchRun starts batch run(s) and wait for its completion with showing progress
 func ExecuteBatchRun(urlBase string, apiToken string, organization string, project string,
-	httpHeadersMap map[string]string, testSettingsNumber int, branchName string,  setting string,
+	httpHeadersMap map[string]string, testSettingsNumber int, branchName string, setting string,
 	waitForResult bool, waitLimit int, printResult bool) (*BatchRun /*on which magicpod bitrise step depends */, bool, bool, *cli.ExitError) {
 	// send batch run start request
 	batchRun, exitErr := StartBatchRun(urlBase, apiToken, organization, project, httpHeadersMap, testSettingsNumber, branchName, setting)

--- a/common/common.go
+++ b/common/common.go
@@ -202,7 +202,7 @@ func StartBatchRun(urlBase string, apiToken string, organization string, project
 				testSettingsBranchInJSON, hasTestSettingsBranch := testSettingsMap["branch_name"]
 				if branchName != "" {
 					if hasTestSettingsBranch && branchName != testSettingsBranchInJSON {
-						return nil, cli.NewExitError("--branch_number and --setting have different branch name", 1)
+						return nil, cli.NewExitError("--branch_name and --setting have different branch name", 1)
 					}
 					testSettingsMap["branch_name"] = branchName
 				}

--- a/common/common.go
+++ b/common/common.go
@@ -199,6 +199,13 @@ func StartBatchRun(urlBase string, apiToken string, organization string, project
 			if ok {
 				_, hasTestSettings := testSettingsMap["test_settings"]
 				testSettingsNumberInJSON, hasTestSettingsNumber := testSettingsMap["test_settings_number"]
+				testSettingsBranchInJSON, hasTestSettingsBranch := testSettingsMap["branch_name"]
+				if branchName != "" {
+					if hasTestSettingsBranch && branchName != testSettingsBranchInJSON {
+						return nil, cli.NewExitError("--branch_number and --setting have different branch name", 1)
+					}
+					testSettingsMap["branch_name"] = branchName
+				}
 				if testSettingsNumber != 0 {
 					if hasTestSettingsNumber && testSettingsNumber != testSettingsNumberInJSON {
 						return nil, cli.NewExitError("--test_settings_number and --setting have different number", 1)

--- a/common/common.go
+++ b/common/common.go
@@ -187,7 +187,11 @@ func StartBatchRun(urlBase string, apiToken string, organization string, project
 	var testSettings interface{}
 	isCrossBatchRunSetting := (testSettingsNumber != 0)
 	if setting == "" {
-		setting = "{\"test_settings_number\":" + strconv.Itoa(testSettingsNumber) + ", \"branch_name\":\"" + branchName + "\"}"
+		var branchJsonString = ""
+		if branchName != "" {
+			branchJsonString = ", \"branch_name\":\"" + branchName + "\""
+		}
+		setting = "{\"test_settings_number\":" + strconv.Itoa(testSettingsNumber) + branchJsonString + "}"
 	} else {
 		err := json.Unmarshal([]byte(setting), &testSettings)
 		if err == nil {

--- a/common/common.go
+++ b/common/common.go
@@ -36,7 +36,7 @@ type BatchRun struct {
 	ProjectName      string `json:"project_name"`
 	BatchRunNumber   int    `json:"batch_run_number"`
 	TestSettingName  string `json:"test_setting_name"`
-	BranchName  string `json:"branch_name"`
+	BranchName       string `json:"branch_name"`
 	Status           string `json:"status"`
 	StatusNumber     int    `json:"status_number"`
 	taskInterval

--- a/common/common.go
+++ b/common/common.go
@@ -36,6 +36,7 @@ type BatchRun struct {
 	ProjectName      string `json:"project_name"`
 	BatchRunNumber   int    `json:"batch_run_number"`
 	TestSettingName  string `json:"test_setting_name"`
+	BranchName  string `json:"branch_name"`
 	Status           string `json:"status"`
 	StatusNumber     int    `json:"status_number"`
 	taskInterval
@@ -182,11 +183,11 @@ func mergeTestSettingsNumberToSetting(testSettingsMap map[string]interface{}, ha
 }
 
 // StartBatchRun starts a batch run or a cross batch run on the server
-func StartBatchRun(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string, testSettingsNumber int, setting string) (*BatchRun, *cli.ExitError) {
+func StartBatchRun(urlBase string, apiToken string, organization string, project string, httpHeadersMap map[string]string, testSettingsNumber int, branchName string, setting string) (*BatchRun, *cli.ExitError) {
 	var testSettings interface{}
 	isCrossBatchRunSetting := (testSettingsNumber != 0)
 	if setting == "" {
-		setting = "{\"test_settings_number\":" + strconv.Itoa(testSettingsNumber) + "}"
+		setting = "{\"test_settings_number\":" + strconv.Itoa(testSettingsNumber) + ", \"branch_name\":\"" + branchName + "\"}"
 	} else {
 		err := json.Unmarshal([]byte(setting), &testSettings)
 		if err == nil {
@@ -419,10 +420,10 @@ func printMessage(printResult bool, format string, args ...interface{}) {
 
 // ExecuteBatchRun starts batch run(s) and wait for its completion with showing progress
 func ExecuteBatchRun(urlBase string, apiToken string, organization string, project string,
-	httpHeadersMap map[string]string, testSettingsNumber int, setting string,
+	httpHeadersMap map[string]string, testSettingsNumber int, branchName string,  setting string,
 	waitForResult bool, waitLimit int, printResult bool) (*BatchRun /*on which magicpod bitrise step depends */, bool, bool, *cli.ExitError) {
 	// send batch run start request
-	batchRun, exitErr := StartBatchRun(urlBase, apiToken, organization, project, httpHeadersMap, testSettingsNumber, setting)
+	batchRun, exitErr := StartBatchRun(urlBase, apiToken, organization, project, httpHeadersMap, testSettingsNumber, branchName, setting)
 	if exitErr != nil {
 		return nil, false, false, exitErr
 	}

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -33,7 +33,7 @@ func main() {
 					Usage: "Test settings number defined in the project batch run page",
 				},
 				cli.StringFlag{
-					Name:  "branch_name, br",
+					Name:  "branch_name, B",
 					Usage: "Branch name",
 				},
 				cli.StringFlag{

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -33,7 +33,7 @@ func main() {
 					Usage: "Test settings number defined in the project batch run page",
 				},
 				cli.StringFlag{
-					Name:  "branch_name, B",
+					Name:  "branch_name, br",
 					Usage: "Branch name",
 				},
 				cli.StringFlag{

--- a/magicpod-api-client.go
+++ b/magicpod-api-client.go
@@ -33,6 +33,10 @@ func main() {
 					Usage: "Test settings number defined in the project batch run page",
 				},
 				cli.StringFlag{
+					Name:  "branch_name, B",
+					Usage: "Branch name",
+				},
+				cli.StringFlag{
 					Name:  "setting, s",
 					Usage: "Test setting in JSON format. Please check https://app.magicpod.com/api/v1.0/doc/ for more detail",
 				},
@@ -326,6 +330,7 @@ func batchRunAction(c *cli.Context) error {
 		return err
 	}
 	testSettingsNumber := c.Int("test_settings_number")
+	branchName := c.String("branch_name")
 	setting := c.String("setting")
 	if testSettingsNumber == 0 && setting == "" {
 		return cli.NewExitError("Either of --test_settings_number or --setting option is required", 1)
@@ -334,7 +339,7 @@ func batchRunAction(c *cli.Context) error {
 	waitLimit := c.Int("wait_limit")
 
 	_, existsErr, existsUnresolved, batchRunError := common.ExecuteBatchRun(urlBase, apiToken, organization,
-		project, httpHeadersMap, testSettingsNumber, setting, !noWait, waitLimit, true)
+		project, httpHeadersMap, testSettingsNumber, branchName, setting, !noWait, waitLimit, true)
 	if batchRunError != nil {
 		return batchRunError
 	}


### PR DESCRIPTION
## Urgency
Normal 😌

## Background
N/A

## Purpose
add option "-B" for branch for batch-run

## Proposed Changes
add option "-B" for branch for batch-run
(if "-B" is not determined, the default branch is set.)

## What I Confirmed
- "-B target-branch": run on the target-branch / "" : run on default branch

<img width="766" alt="Screenshot 2025-05-20 at 17 26 27" src="https://github.com/user-attachments/assets/3eb975f1-50ea-42fd-b12e-bb4abb7e0d84" />

<img width="770" alt="Screenshot 2025-05-20 at 17 26 17" src="https://github.com/user-attachments/assets/e5ada111-c6cf-497c-bf0f-93eb5bd6f222" />

![Screenshot 2025-05-20 at 17 27 27](https://github.com/user-attachments/assets/032b54ec-0baa-492e-8cdb-c7aec79a7faf)


## Tasks After the Merge
N/A

## Related
N/A