### PR TITLE
fix: not to delete branch when setting is included

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -177,7 +177,7 @@ func mergeTestSettingsNumberToSetting(testSettingsMap map[string]interface{}, ha
 		miscSettings := make(map[string]interface{})
 		keysToDelete := []string{}
 		for k, v := range testSettingsMap {
-			if k != "test_settings_number" && k != "concurrency" && k != "test_settings_name" {
+			if k != "test_settings_number" && k != "concurrency" && k != "test_settings_name" && k != "branch_name" {
 				miscSettings[k] = v
 				keysToDelete = append(keysToDelete, k)
 			}


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate with the reviewer regarding the motivation. If it fixes a bug or resolves a feature request, surely provide the link to that issue.
-->

When setting str (`-s`) is included, branch info is deleted.
However, a branch info should not be deleted regardless of the existence of the setting str.

This change is needed to support a branch on [bitrise-step-magic-pod](https://github.com/Magic-Pod/bitrise-step-magic-pod) because `app_file_number` is added as [settingsStr](https://github.com/Magic-Pod/bitrise-step-magic-pod/blob/a16c6c0fe7535b29ffff8b51439157ca27a46d51/main.go#L98-L103).

## What I checked

I checked the behavior like this command.
```
$ ./magicpod-api-client batch-run -n -t ${MAGIC_POD_AUTH_TOKEN_PROD} -o <organization> -p <project> -S <test_settings_number>
-B <branch> -s "{\"app_file_number\": 20}"
```

- Before this change, a branch was ignored.
- After this change, a branch is reflected as expected.